### PR TITLE
bugfix: If a local volume is SpdkLVol type, connect the target

### DIFF
--- a/hack/deploy/base/500-disk-operator.yaml
+++ b/hack/deploy/base/500-disk-operator.yaml
@@ -48,7 +48,7 @@ spec:
           secretName: selfsigned-cert-tls
       containers:
       - name: node-disk-controller
-        image: silentred/node-disk-controller:7184e038-20231129171234
+        image: silentred/node-disk-controller:ba03b9e2-20231129185104
         command:
         - /node-disk-controller
         args:

--- a/hack/deploy/base/600-csi-controller.yaml
+++ b/hack/deploy/base/600-csi-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: obnvmf-admin
       containers:
       - name: csi-antstor
-        image: silentred/node-disk-controller:7184e038-20231129171234
+        image: silentred/node-disk-controller:ba03b9e2-20231129185104
         command:
         - /node-disk-controller
         args:

--- a/hack/deploy/base/700-disk-agent.yaml
+++ b/hack/deploy/base/700-disk-agent.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["ALL"]
             allowPrivilegeEscalation: true
-          image: silentred/node-disk-controller:7184e038-20231129171234
+          image: silentred/node-disk-controller:ba03b9e2-20231129185104
           #imagePullPolicy: Always
           command:
             - /node-disk-controller

--- a/hack/deploy/base/800-csi-node.yaml
+++ b/hack/deploy/base/800-csi-node.yaml
@@ -26,7 +26,7 @@ spec:
             capabilities:
               add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN", "SYS_RAWIO"]
             allowPrivilegeEscalation: true
-          image: silentred/node-disk-controller:7184e038-20231129171234
+          image: silentred/node-disk-controller:ba03b9e2-20231129185104
           command:
           - /node-disk-controller
           args:


### PR DESCRIPTION
I found a pod hangs at ContainerCreating status, if the computing node and target node are the same, and the volume is SpdkLVol type.

The problem is at this line: 
https://github.com/eosphoros-ai/liteio/blob/290e8b6b468dd8aae4564361b604bc9821d938a3/pkg/csi/rpcserver/node.go#L182C15-L182C15


The csi node should connect the target on 2 condition:
1. it is a remote volume
2. the volume is SpdkLVol type, regardless of the position of the volume